### PR TITLE
Ex. didn't work - jsFunction {Unit} does not compile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ object ScalaJSGMapExample extends js.JSApp {
         streetViewControl = false,
         mapTypeControl = false)
         val gmap = new google.maps.Map(document.getElementById("map-canvas"), opts)
+        ""
     }
     google.maps.event.addDomListener(window, "load", initialize)
   }
@@ -63,6 +64,7 @@ object ScalaJSGMapExample extends js.JSApp {
           map = gmap,
           title = "Marker"
         ))
+        ""
     }
     google.maps.event.addDomListener(window, "load", initialize)
   }
@@ -102,9 +104,9 @@ object ScalaJSGMapExample extends js.JSApp {
           println("Marker click !")
           infowindow.open(gmap,marker)
         })
+        ""
     }
     google.maps.event.addDomListener(window, "load", initialize)
   }
 }
 ```
-


### PR DESCRIPTION
Callback js.Function made of Function[Unit] is not possible. Function[Unit] is against FP programming principles.
js.Function[String] is possible.
